### PR TITLE
Add feed metadata to head template

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
       {% include collecttags.html %}
     {% endif %}
   
-    
+    {% feed_meta %}
     {% seo %}	   
 
     <!-- Twitter cards -->


### PR DESCRIPTION
The rendered website currently doesn't announce the existence of an ATOM feed at https://richardstartin.github.io/feed.xml which is being produced by [jekyll-feed](https://github.com/jekyll/jekyll-feed/).

See also: https://github.com/jekyll/jekyll-feed/tree/v0.15.1#meta-tags